### PR TITLE
Use Asc as default Order Direction

### DIFF
--- a/src/FopExpression/FopExpressionBuilder.cs
+++ b/src/FopExpression/FopExpressionBuilder.cs
@@ -42,7 +42,11 @@ namespace Fop.FopExpression
 
             var orderParts = order.Split(';');
 
-            var direction = orderParts[1] == "desc" ? OrderDirection.Desc : OrderDirection.Asc;
+            var direction = orderParts.Length > 1 ?
+                orderParts[1] == "desc" 
+                    ? OrderDirection.Desc 
+                    : OrderDirection.Asc
+                : OrderDirection.Asc;
 
             return (orderParts[0], direction);
         }


### PR DESCRIPTION
Fix an issue that happens when the order direction is not sent on the query parameter, this causes the entire request ends throwing an exception.