### PR TITLE
Support long and ulong type on expression builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,20 @@ Supported operators for type are below;
 
 Fop uses these query sign for preparing expression. 
 
-|Operators          |Query Sign  |Int |String | Char |DateTime|
-|-------------------|------------|----|-------|------|--------|
-|Equal              |`==`        | ✔️ | ✔️    | ✔️  | ✔️     |
-|NotEqual           |`!=`        | ✔️ | ✔️    | ✔️  | ✔️     |
-|GreaterThan        |`>`         | ✔️ | ❌    | ❌  | ✔️     |
-|GreaterOrEqualThan |`>=`        | ✔️ | ❌    | ❌  | ✔️     |
-|LessThan           |`<`         | ✔️ | ❌    | ❌  | ✔️     |
-|LessOrEqualThan    |`<=`        | ✔️ | ❌    | ❌  | ✔️     |
-|Contains           |`~=`        | ❌ | ✔️    | ❌  | ❌     | 
-|NotContains        |`!~=`       | ❌ | ✔️    | ❌  | ❌     | 
-|StartsWith         |`_=`        | ❌ | ✔️    | ❌  | ❌     |
-|NotStartsWith      |`!_=`       | ❌ | ✔️    | ❌  | ❌     |
-|EndsWith           |`\|=`       | ❌ | ✔️    | ❌  | ❌     |
-|NotEndsWith        |`!\|=`      | ❌ | ✔️    | ❌  | ❌     |
+|Operators          |Query Sign  |Int/Long |String | Char |DateTime|
+|-------------------|------------|---------|-------|------|--------|
+|Equal              |`==`        | ✔️     | ✔️    | ✔️  | ✔️     |
+|NotEqual           |`!=`        | ✔️     | ✔️    | ✔️  | ✔️     |
+|GreaterThan        |`>`         | ✔️     | ❌    | ❌  | ✔️     |
+|GreaterOrEqualThan |`>=`        | ✔️     | ❌    | ❌  | ✔️     |
+|LessThan           |`<`         | ✔️     | ❌    | ❌  | ✔️     |
+|LessOrEqualThan    |`<=`        | ✔️     | ❌    | ❌  | ✔️     |
+|Contains           |`~=`        | ❌     | ✔️    | ❌  | ❌     | 
+|NotContains        |`!~=`       | ❌     | ✔️    | ❌  | ❌     | 
+|StartsWith         |`_=`        | ❌     | ✔️    | ❌  | ❌     |
+|NotStartsWith      |`!_=`       | ❌     | ✔️    | ❌  | ❌     |
+|EndsWith           |`\|=`       | ❌     | ✔️    | ❌  | ❌     |
+|NotEndsWith        |`!\|=`      | ❌     | ✔️    | ❌  | ❌     |
 
 ##### Example
 api/students/

--- a/src/FopExpression/FopExpressionBuilder.cs
+++ b/src/FopExpression/FopExpressionBuilder.cs
@@ -165,6 +165,12 @@ namespace Fop.FopExpression
                 return FilterDataTypes.Int;
             }
 
+            if (propertyName == "Int64" ||
+                propertyName == "UInt64")
+            {
+                return FilterDataTypes.Long;
+            }
+
             if (propertyName == "String")
             {
                 return FilterDataTypes.String;


### PR DESCRIPTION
I noticed that the type long was not supported and that was causing conflicts with my project that has models with long type properties.

I'm not sure why this primitive type is not supported, because there is a specific strategy (LongDataTypeStrategy) to handle this behavior.

This pull request adds a conditional to check if the type is long or unsigned long, and then set the corresponding FilterDataTypes enumerable value.