### PR TITLE
Support GUID type

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,20 @@ Supported operators for type are below;
 
 Fop uses these query sign for preparing expression. 
 
-|Operators          |Query Sign  |Int |String | Char |DateTime|
-|-------------------|------------|----|-------|------|--------|
-|Equal              |`==`        | ✔️ | ✔️    | ✔️  | ✔️     |
-|NotEqual           |`!=`        | ✔️ | ✔️    | ✔️  | ✔️     |
-|GreaterThan        |`>`         | ✔️ | ❌    | ❌  | ✔️     |
-|GreaterOrEqualThan |`>=`        | ✔️ | ❌    | ❌  | ✔️     |
-|LessThan           |`<`         | ✔️ | ❌    | ❌  | ✔️     |
-|LessOrEqualThan    |`<=`        | ✔️ | ❌    | ❌  | ✔️     |
-|Contains           |`~=`        | ❌ | ✔️    | ❌  | ❌     | 
-|NotContains        |`!~=`       | ❌ | ✔️    | ❌  | ❌     | 
-|StartsWith         |`_=`        | ❌ | ✔️    | ❌  | ❌     |
-|NotStartsWith      |`!_=`       | ❌ | ✔️    | ❌  | ❌     |
-|EndsWith           |`\|=`       | ❌ | ✔️    | ❌  | ❌     |
-|NotEndsWith        |`!\|=`      | ❌ | ✔️    | ❌  | ❌     |
+|Operators          |Query Sign  |Int |String | Char |DateTime|Guid|
+|-------------------|------------|----|-------|------|--------|----|
+|Equal              |`==`        | ✔️ | ✔️    | ✔️  | ✔️    | ✔️ |
+|NotEqual           |`!=`        | ✔️ | ✔️    | ✔️  | ✔️    | ✔️ |
+|GreaterThan        |`>`         | ✔️ | ❌    | ❌  | ✔️    | ❌ |
+|GreaterOrEqualThan |`>=`        | ✔️ | ❌    | ❌  | ✔️    | ❌ |
+|LessThan           |`<`         | ✔️ | ❌    | ❌  | ✔️    | ❌ |
+|LessOrEqualThan    |`<=`        | ✔️ | ❌    | ❌  | ✔️    | ❌ |
+|Contains           |`~=`        | ❌ | ✔️    | ❌  | ❌    | ❌ |
+|NotContains        |`!~=`       | ❌ | ✔️    | ❌  | ❌    | ❌ |
+|StartsWith         |`_=`        | ❌ | ✔️    | ❌  | ❌    | ❌ |
+|NotStartsWith      |`!_=`       | ❌ | ✔️    | ❌  | ❌    | ❌ |
+|EndsWith           |`\|=`       | ❌ | ✔️    | ❌  | ❌    | ❌ |
+|NotEndsWith        |`!\|=`      | ❌ | ✔️    | ❌  | ❌    | ❌ |
 
 ##### Example
 api/students/

--- a/src/Exceptions/GuidDataTypeNotSupportedException.cs
+++ b/src/Exceptions/GuidDataTypeNotSupportedException.cs
@@ -1,0 +1,9 @@
+﻿namespace Fop.Exceptions
+{
+    public class GuidDataTypeNotSupportedException : FopException
+    {
+
+        public GuidDataTypeNotSupportedException(string message) : base(message) { }
+
+    }
+}

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -26,6 +26,7 @@ namespace Fop
             DataTypeStrategies.Add(FilterDataTypes.DateTime, new DateTimeDataTypeStrategy());
             DataTypeStrategies.Add(FilterDataTypes.Boolean, new BooleanDataTypeStrategy());
             DataTypeStrategies.Add(FilterDataTypes.Enum, new EnumDataTypeStrategy());
+            DataTypeStrategies.Add(FilterDataTypes.Guid, new GuidTypeStrategy());
         }
 
         public static (IQueryable<T>, int) ApplyFop<T>(this IQueryable<T> source, IFopRequest request)

--- a/src/Filter/FilterEnumerations.cs
+++ b/src/Filter/FilterEnumerations.cs
@@ -33,6 +33,7 @@
         Char,
         DateTime,
         Boolean,
-        Enum
+        Enum,
+        Guid
     }
 }

--- a/src/FopExpression/FopExpressionBuilder.cs
+++ b/src/FopExpression/FopExpressionBuilder.cs
@@ -185,6 +185,11 @@ namespace Fop.FopExpression
                 return FilterDataTypes.Boolean;
             }
 
+            if (propertyName == "Guid")
+            {
+                return FilterDataTypes.Guid;
+            }
+
             throw new ArgumentOutOfRangeException();
         }
 

--- a/src/Strategies/GuidTypeStrategy.cs
+++ b/src/Strategies/GuidTypeStrategy.cs
@@ -1,0 +1,31 @@
+﻿using Fop.Exceptions;
+using Fop.Filter;
+
+namespace Fop.Strategies
+{
+    public class GuidTypeStrategy : IFilterDataTypeStrategy
+    {
+        public string ConvertFilterToText(IFilter filter)
+        {
+            switch (filter.Operator)
+            {
+                case FilterOperators.Equal:
+                    return filter.Key + " ==  new Guid(\"" + filter.Value + "\")";
+                case FilterOperators.NotEqual:
+                    return filter.Key + " != new Guid(\"" + filter.Value + "\")";
+                case FilterOperators.Contains:
+                case FilterOperators.NotContains:
+                case FilterOperators.StartsWith:
+                case FilterOperators.NotStartsWith:
+                case FilterOperators.EndsWith:
+                case FilterOperators.NotEndsWith:
+                case FilterOperators.GreaterThan:
+                case FilterOperators.GreaterOrEqualThan:
+                case FilterOperators.LessThan:
+                case FilterOperators.LessOrEqualThan:
+                default:
+                    throw new StringDataTypeNotSupportedException($"String filter does not support {filter.Operator}");
+            }
+        }
+    }
+}

--- a/src/Strategies/GuidTypeStrategy.cs
+++ b/src/Strategies/GuidTypeStrategy.cs
@@ -24,7 +24,7 @@ namespace Fop.Strategies
                 case FilterOperators.LessThan:
                 case FilterOperators.LessOrEqualThan:
                 default:
-                    throw new StringDataTypeNotSupportedException($"Guid filter does not support {filter.Operator}");
+                    throw new GuidDataTypeNotSupportedException($"Guid filter does not support {filter.Operator}");
             }
         }
     }

--- a/src/Strategies/GuidTypeStrategy.cs
+++ b/src/Strategies/GuidTypeStrategy.cs
@@ -24,7 +24,7 @@ namespace Fop.Strategies
                 case FilterOperators.LessThan:
                 case FilterOperators.LessOrEqualThan:
                 default:
-                    throw new StringDataTypeNotSupportedException($"String filter does not support {filter.Operator}");
+                    throw new StringDataTypeNotSupportedException($"Guid filter does not support {filter.Operator}");
             }
         }
     }


### PR DESCRIPTION
The `Guid` type is already supported by the [DynamicExpresso](https://github.com/davideicardi/DynamicExpresso) library.

This Pull Request adds a strategy to handle `Guid` types.